### PR TITLE
Scan & fix GitHub workflow security issues using zizmor

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,12 +9,6 @@ on:  # yamllint disable-line rule:truthy
     - cron: '30 2 * * *'  # Run at 02:30 UTC daily
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 # Allow only one concurrent deployment
 concurrency:
   group: "pages"
@@ -24,22 +18,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
         with:
           python-version: '3.12'
 
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
       - name: Setup virtual environment and install dependencies
         run: |
           uv venv
           uv pip install ".[test]"
 
       - name: Clone yle-guide-scraper
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
+          persist-credentials: false
           repository: akaihola/yle-guide-scraper
           path: yle-guide-scraper
 
@@ -56,11 +54,14 @@ jobs:
           cp templates/*.{js,css} _site/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: _site
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -69,4 +70,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5


### PR DESCRIPTION
Fix the following warnings from zizmor:
- [x] warning[artipacked]: credential persistence through GitHub Actions artifacts
- [x] error[excessive-permissions]: overly broad workflow or job-level permissions
- [x] help[unpinned-uses]: unpinned action reference

Also:
- [ ] Add a zizmor workflow